### PR TITLE
References to Mail 1.2.0 corrected to use Mail2

### DIFF
--- a/Mail2.php
+++ b/Mail2.php
@@ -175,8 +175,8 @@ class Mail2
 
         foreach ($headers as $key => $value) {
             if (strcasecmp($key, 'From') === 0) {
-                include_once 'Mail/RFC822.php';
-                $parser = new Mail_RFC822();
+                include_once 'Mail2/RFC822.php';
+                $parser = new Mail2_RFC822();
                 $addresses = $parser->parseAddressList($value, 'localhost', false);
                 if (is_a($addresses, 'PEAR_Error')) {
                     return $addresses;
@@ -230,7 +230,7 @@ class Mail2
      */
     protected function parseRecipients($recipients)
     {
-        include_once 'Mail/RFC822.php';
+        include_once 'Mail2/RFC822.php';
 
         // if we're passed an array, assume addresses are valid and
         // implode them before parsing.
@@ -241,8 +241,8 @@ class Mail2
         // Parse recipients, leaving out all personal info. This is
         // for smtp recipients, etc. All relevant personal information
         // should already be in the headers.
-        $Mail_RFC822 = new Mail_RFC822();
-        $addresses = $Mail_RFC822->parseAddressList($recipients, 'localhost', false);
+        $Mail2_RFC822 = new Mail2_RFC822();
+        $addresses = $Mail2_RFC822->parseAddressList($recipients, 'localhost', false);
 
         $recipients = array();
         if (is_array($addresses)) {


### PR DESCRIPTION
Some functions (parseRecipients and prepareHeaders) were still refering to the old Mail 1.2.0 release instead of refering to new Mail2
